### PR TITLE
Update interceptor for work with other http events

### DIFF
--- a/src/abpHttpInterceptor.ts
+++ b/src/abpHttpInterceptor.ts
@@ -328,6 +328,8 @@ export class AbpHttpInterceptor implements HttpInterceptor {
                 interceptObservable.next(event);
                 interceptObservable.complete();
             }
+        } else {
+            interceptObservable.next(event);
         }
     }
 


### PR DESCRIPTION
If I want to get the download progress, I need the interceptor can work with `HttpEventType.UploadProgress`

```typescript
return this._http
            .post(this.url, formData, {
                reportProgress: true,
                observe: 'events',
            })
            .pipe(
                tap((event: HttpEvent<any>) => {
                    console.log(event);

                    if (event.type === HttpEventType.UploadProgress) {
                        const percentDone = Math.round(
                            (100 * event.loaded) / event.total,
                        );
                        console.log(percentDone);
                    }
                }),
                filter(
                    (event: HttpEvent<any>) =>
                        event.type === HttpEventType.Response,
                ),
                map(responce =>
                    this._mapUploadResponce(fileSource, fis, responce),
                ),
            );
```