### PR TITLE
Angular refresh token implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
   "peerDependencies": {
     "@angular/common": "^8.0.0",
     "@angular/core": "^8.0.0",
-    "abp-web-resources": "^4.1.0"
+    "abp-web-resources": "^4.2.0"
   },
   "devDependencies": {
     "@angular/common": "^8.0.0",
     "@angular/compiler": "^8.0.0",
     "@angular/compiler-cli": "^8.0.0",
     "@angular/core": "^8.0.0",
-    "abp-web-resources": "^4.1.0",
+    "abp-web-resources": "^4.2.0",
     "copyfiles": "^2.1.0",
     "rimraf": "^2.6.2",
     "rollup": "^0.68.1",

--- a/src/abpHttpInterceptor.ts
+++ b/src/abpHttpInterceptor.ts
@@ -234,7 +234,7 @@ export class AbpHttpInterceptor implements HttpInterceptor {
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
 
         var interceptObservable = new Subject<HttpEvent<any>>();
-        var modifiedRequest = this.normalizeRequestHeaders(request); 
+        var modifiedRequest = this.normalizeRequestHeaders(request);
         next.handle(modifiedRequest)
             .pipe(
                 catchError(error => {
@@ -420,7 +420,7 @@ export class AbpHttpInterceptor implements HttpInterceptor {
             } else {
                 this.configuration.handleNonAbpErrorResponse(errorResponse);
             }
-
+            
             errorObservable.complete();
 
             interceptObservable.error(error);

--- a/src/abpHttpInterceptor.ts
+++ b/src/abpHttpInterceptor.ts
@@ -257,14 +257,10 @@ export class AbpHttpInterceptor implements HttpInterceptor {
     }
 
     protected tryGetRefreshTokenService(): Observable<boolean> {
-        try {
-            var _refreshTokenService = this._injector.get(RefreshTokenService);
+        var _refreshTokenService = this._injector.get(RefreshTokenService, null);
 
-            if (_refreshTokenService) {
-                return _refreshTokenService.tryAuthWithRefreshToken();
-            }
-        } catch (error) {
-            return of(false);
+        if (_refreshTokenService) {
+            return _refreshTokenService.tryAuthWithRefreshToken();
         }
         return of(false);
     }

--- a/src/abpHttpInterceptor.ts
+++ b/src/abpHttpInterceptor.ts
@@ -290,7 +290,7 @@ export class AbpHttpInterceptor implements HttpInterceptor {
                 }));
         } else {
             return this.refreshTokenSubject.pipe(
-                filter(token => token != null),
+                filter(authResult => authResult != null),
                 take(1),
                 switchMap(authResult => {
                     let modifiedRequest = this.normalizeRequestHeaders(request);

--- a/src/auth/token.service.ts
+++ b/src/auth/token.service.ts
@@ -19,4 +19,20 @@ export class TokenService {
         abp.auth.setToken(authToken, expireDate);
     }
 
+    //refresh token
+    getRefreshToken(): string {
+        return abp.auth.getRefreshToken();
+    }
+
+    getRefreshTokenCookieName(): string {
+        return abp.auth.refreshTokenCookieName;
+    }
+
+    clearRefreshToken(): void {
+        abp.auth.clearRefreshToken();
+    }
+
+    setRefreshToken(refreshToken: string, expireDate?: Date): void {
+        abp.auth.setRefreshToken(refreshToken, expireDate);
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,10 +52,10 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
-abp-web-resources@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/abp-web-resources/-/abp-web-resources-4.1.0.tgz#b97e4939c6341423707da8d40ad63bc19aa1e697"
-  integrity sha512-HKL+x7WmpVKNCVG+5bpHP1swMl+ujIn3FoB4bqJyUHvLvswwo6ZJwckKO1ZoLQMqMK67ElXcpgYxJuZUrInhDg==
+abp-web-resources@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/abp-web-resources/-/abp-web-resources-4.2.0.tgz#8c395257fa4b22532c175ace412f463ac25c0120"
+  integrity sha512-ABGDISOyZZmwcn0CyLl//9yDj8gtTSGzTK+smMWMkO9sOgf71k2Y5QIbNmoxfhJGTG3hHcK4tLLMO3rGUZyCTQ==
 
 ansi-regex@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
Refresh token implementation.
Class named RefreshTokenService added. If project has implementation for RefreshTokenService and any request gets 401, AbpHttpInterceptor :
* will block all request,
* store them in BehaviorSubject
* try to get access token
* if it success, rehandle all requests.
* otherwise go login 

![Screenshot_6](https://user-images.githubusercontent.com/48536631/68746120-f3eb2380-0608-11ea-8dff-213734ea36eb.png)

if there is no RefreshTokenService it will not try to use refresh token.

**Waiting for https://github.com/aspnetboilerplate/bower-abp-resources/pull/21,** 
- [x] **Then upgrade abp-web-resources**
